### PR TITLE
extend personal-commitment window

### DIFF
--- a/src/functions/updateDmsTaskWithDates/framework/task-modifier.ts
+++ b/src/functions/updateDmsTaskWithDates/framework/task-modifier.ts
@@ -96,11 +96,11 @@ function addDateFilters(options: Options) {
 
   addOnOrBeforeFilter(options, 'PERSONAL_COMMITMENT', 'START_DATE_TIME',
                       personalCommitmentEndDateTime, logger);
-  addOnOrAfterFilter(options, 'PERSONAL_COMMITMENT', 'END_DATE_TIME', startDate, logger);
+  addOnOrAfterFilter(options, 'PERSONAL_COMMITMENT', 'END_DATE_TIME', journalStartDate, logger);
 
   const deploymentEndDate = startDate.plus(deploymentTimeWindow);
   addOnOrBeforeFilter(options, 'DEPLOYMENT', 'START_DATE', deploymentEndDate, logger);
-  addOnOrAfterFilter(options, 'DEPLOYMENT', 'END_DATE', startDate, logger);
+  addOnOrAfterFilter(options, 'DEPLOYMENT', 'END_DATE', journalStartDate, logger);
 
   const ethnicOriginStartDate = startDate.minus(Duration.fromObject({ years: 3 }));
   addBetweenFilter(options, 'ETHNIC_ORIGIN', 'LOADED_DATE', ethnicOriginStartDate, startDate, logger);


### PR DESCRIPTION
Personal commitments prior to today are not being transferred via DMS (thus not appearing on the journal for anything earlier than today).

Amended DMS task to take account of the journal window for the start date.

